### PR TITLE
Improve descriptor error messages

### DIFF
--- a/alluka/_self_injecting.py
+++ b/alluka/_self_injecting.py
@@ -38,9 +38,7 @@ from collections import abc as collections
 from . import abc as alluka
 
 _CallbackSigT = typing.TypeVar("_CallbackSigT", bound=alluka.CallbackSig[typing.Any])
-_SyncCallbackT = typing.TypeVar(
-    "_SyncCallbackT", bound=collections.Callable[..., typing.Any]
-)
+_SyncCallbackT = typing.TypeVar("_SyncCallbackT", bound=collections.Callable[..., typing.Any])
 _T = typing.TypeVar("_T")
 _CoroT = collections.Coroutine[typing.Any, typing.Any, _T]
 
@@ -96,24 +94,19 @@ class AsyncSelfInjecting(alluka.AsyncSelfInjecting[_CallbackSigT]):
 
     @typing.overload
     async def __call__(
-        self: AsyncSelfInjecting[collections.Callable[..., _CoroT[_T]]],
-        *args: typing.Any,
-        **kwargs: typing.Any,
+        self: AsyncSelfInjecting[collections.Callable[..., _CoroT[_T]]], *args: typing.Any, **kwargs: typing.Any
     ) -> _T:
         ...
 
     @typing.overload
     async def __call__(
-        self: AsyncSelfInjecting[collections.Callable[..., _T]],
-        *args: typing.Any,
-        **kwargs: typing.Any,
+        self: AsyncSelfInjecting[collections.Callable[..., _T]], *args: typing.Any, **kwargs: typing.Any
     ) -> _T:
         ...
 
     async def __call__(  # pyright: ignore[reportIncompatibleMethodOverride]
         self: typing.Union[
-            AsyncSelfInjecting[collections.Callable[..., _T]],
-            AsyncSelfInjecting[collections.Callable[..., _CoroT[_T]]],
+            AsyncSelfInjecting[collections.Callable[..., _T]], AsyncSelfInjecting[collections.Callable[..., _CoroT[_T]]]
         ],
         *args: typing.Any,
         **kwargs: typing.Any,
@@ -178,11 +171,7 @@ class SelfInjecting(alluka.SelfInjecting[_SyncCallbackT]):
         self._callback = callback
         self._client = client
 
-    def __call__(
-        self: SelfInjecting[collections.Callable[..., _T]],
-        *args: typing.Any,
-        **kwargs: typing.Any,
-    ) -> _T:
+    def __call__(self: SelfInjecting[collections.Callable[..., _T]], *args: typing.Any, **kwargs: typing.Any) -> _T:
         # <<inherited docstring from alluka.abc.SelfInjecting>>.
         return self._client.call_with_di(self._callback, *args, **kwargs)
 

--- a/alluka/_self_injecting.py
+++ b/alluka/_self_injecting.py
@@ -38,13 +38,15 @@ from collections import abc as collections
 from . import abc as alluka
 
 _CallbackSigT = typing.TypeVar("_CallbackSigT", bound=alluka.CallbackSig[typing.Any])
-_SyncCallbackT = typing.TypeVar("_SyncCallbackT", bound=collections.Callable[..., typing.Any])
+_SyncCallbackT = typing.TypeVar(
+    "_SyncCallbackT", bound=collections.Callable[..., typing.Any]
+)
 _T = typing.TypeVar("_T")
 _CoroT = collections.Coroutine[typing.Any, typing.Any, _T]
 
 
 class AsyncSelfInjecting(alluka.AsyncSelfInjecting[_CallbackSigT]):
-    """Class used to link a sync function to a client to make it self-injecting.
+    """Class used to link an async function to a client to make it self-injecting.
 
     Examples
     --------
@@ -94,19 +96,24 @@ class AsyncSelfInjecting(alluka.AsyncSelfInjecting[_CallbackSigT]):
 
     @typing.overload
     async def __call__(
-        self: AsyncSelfInjecting[collections.Callable[..., _CoroT[_T]]], *args: typing.Any, **kwargs: typing.Any
+        self: AsyncSelfInjecting[collections.Callable[..., _CoroT[_T]]],
+        *args: typing.Any,
+        **kwargs: typing.Any,
     ) -> _T:
         ...
 
     @typing.overload
     async def __call__(
-        self: AsyncSelfInjecting[collections.Callable[..., _T]], *args: typing.Any, **kwargs: typing.Any
+        self: AsyncSelfInjecting[collections.Callable[..., _T]],
+        *args: typing.Any,
+        **kwargs: typing.Any,
     ) -> _T:
         ...
 
     async def __call__(  # pyright: ignore[reportIncompatibleMethodOverride]
         self: typing.Union[
-            AsyncSelfInjecting[collections.Callable[..., _T]], AsyncSelfInjecting[collections.Callable[..., _CoroT[_T]]]
+            AsyncSelfInjecting[collections.Callable[..., _T]],
+            AsyncSelfInjecting[collections.Callable[..., _CoroT[_T]]],
         ],
         *args: typing.Any,
         **kwargs: typing.Any,
@@ -171,7 +178,11 @@ class SelfInjecting(alluka.SelfInjecting[_SyncCallbackT]):
         self._callback = callback
         self._client = client
 
-    def __call__(self: SelfInjecting[collections.Callable[..., _T]], *args: typing.Any, **kwargs: typing.Any) -> _T:
+    def __call__(
+        self: SelfInjecting[collections.Callable[..., _T]],
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> _T:
         # <<inherited docstring from alluka.abc.SelfInjecting>>.
         return self._client.call_with_di(self._callback, *args, **kwargs)
 

--- a/alluka/_types.py
+++ b/alluka/_types.py
@@ -92,14 +92,10 @@ class InjectedCallback:
             If any of the callback's type dependencies aren't implemented by
             the context's client.
         """
-        callback = (
-            ctx.injection_client.get_callback_override(self.callback) or self.callback
-        )
+        callback = ctx.injection_client.get_callback_override(self.callback) or self.callback
         return ctx.injection_client.call_with_ctx(ctx, callback)
 
-    def resolve_async(
-        self, ctx: alluka.Context
-    ) -> collections.Coroutine[typing.Any, typing.Any, typing.Any]:
+    def resolve_async(self, ctx: alluka.Context) -> collections.Coroutine[typing.Any, typing.Any, typing.Any]:
         """Asynchronously resolve the callback.
 
         Parameters
@@ -113,9 +109,7 @@ class InjectedCallback:
             If any of the callback's type dependencies aren't implemented by
             the context's client.
         """
-        callback = (
-            ctx.injection_client.get_callback_override(self.callback) or self.callback
-        )
+        callback = ctx.injection_client.get_callback_override(self.callback) or self.callback
         return ctx.injection_client.call_with_ctx_async(ctx, callback)
 
 
@@ -162,17 +156,14 @@ class InjectedType:
             The resolved type.
         """
         for cls in self.types:
-            if (
-                result := ctx.get_type_dependency(cls, default=UNDEFINED)
-            ) is not UNDEFINED:
+            if (result := ctx.get_type_dependency(cls, default=UNDEFINED)) is not UNDEFINED:
                 return result
 
         if self.default is not UNDEFINED:
             return self.default
 
         raise _errors.MissingDependencyError(
-            f"Couldn't resolve injected type(s) {self.repr_type} to actual value",
-            self.repr_type,
+            f"Couldn't resolve injected type(s) {self.repr_type} to actual value", self.repr_type
         ) from None
 
 

--- a/alluka/_types.py
+++ b/alluka/_types.py
@@ -29,9 +29,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """Internal types used by Alluka."""
-from __future__ import annotations
 
-from typing import Any
+from __future__ import annotations
 
 __all__: list[str] = ["Injected", "InjectedDescriptor"]
 
@@ -93,10 +92,14 @@ class InjectedCallback:
             If any of the callback's type dependencies aren't implemented by
             the context's client.
         """
-        callback = ctx.injection_client.get_callback_override(self.callback) or self.callback
+        callback = (
+            ctx.injection_client.get_callback_override(self.callback) or self.callback
+        )
         return ctx.injection_client.call_with_ctx(ctx, callback)
 
-    def resolve_async(self, ctx: alluka.Context) -> collections.Coroutine[typing.Any, typing.Any, typing.Any]:
+    def resolve_async(
+        self, ctx: alluka.Context
+    ) -> collections.Coroutine[typing.Any, typing.Any, typing.Any]:
         """Asynchronously resolve the callback.
 
         Parameters
@@ -110,7 +113,9 @@ class InjectedCallback:
             If any of the callback's type dependencies aren't implemented by
             the context's client.
         """
-        callback = ctx.injection_client.get_callback_override(self.callback) or self.callback
+        callback = (
+            ctx.injection_client.get_callback_override(self.callback) or self.callback
+        )
         return ctx.injection_client.call_with_ctx_async(ctx, callback)
 
 
@@ -157,14 +162,17 @@ class InjectedType:
             The resolved type.
         """
         for cls in self.types:
-            if (result := ctx.get_type_dependency(cls, default=UNDEFINED)) is not UNDEFINED:
+            if (
+                result := ctx.get_type_dependency(cls, default=UNDEFINED)
+            ) is not UNDEFINED:
                 return result
 
         if self.default is not UNDEFINED:
             return self.default
 
         raise _errors.MissingDependencyError(
-            f"Couldn't resolve injected type(s) {self.repr_type} to actual value", self.repr_type
+            f"Couldn't resolve injected type(s) {self.repr_type} to actual value",
+            self.repr_type,
         ) from None
 
 
@@ -258,7 +266,7 @@ class InjectedDescriptor(typing.Generic[_T]):
         self.callback = callback
         self.type = type
 
-    def __getattr__(self, __name: str) -> Any:
+    def __getattr__(self, __name: str) -> typing.NoReturn:
         raise AttributeError(
             "Tried accessing a parameter that was not injected yet. Did you forget to inject dependencies?"
         )

--- a/alluka/_types.py
+++ b/alluka/_types.py
@@ -30,6 +30,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """Internal types used by Alluka."""
 from __future__ import annotations
+
 from typing import Any
 
 __all__: list[str] = ["Injected", "InjectedDescriptor"]
@@ -92,14 +93,10 @@ class InjectedCallback:
             If any of the callback's type dependencies aren't implemented by
             the context's client.
         """
-        callback = (
-            ctx.injection_client.get_callback_override(self.callback) or self.callback
-        )
+        callback = ctx.injection_client.get_callback_override(self.callback) or self.callback
         return ctx.injection_client.call_with_ctx(ctx, callback)
 
-    def resolve_async(
-        self, ctx: alluka.Context
-    ) -> collections.Coroutine[typing.Any, typing.Any, typing.Any]:
+    def resolve_async(self, ctx: alluka.Context) -> collections.Coroutine[typing.Any, typing.Any, typing.Any]:
         """Asynchronously resolve the callback.
 
         Parameters
@@ -113,9 +110,7 @@ class InjectedCallback:
             If any of the callback's type dependencies aren't implemented by
             the context's client.
         """
-        callback = (
-            ctx.injection_client.get_callback_override(self.callback) or self.callback
-        )
+        callback = ctx.injection_client.get_callback_override(self.callback) or self.callback
         return ctx.injection_client.call_with_ctx_async(ctx, callback)
 
 
@@ -162,17 +157,14 @@ class InjectedType:
             The resolved type.
         """
         for cls in self.types:
-            if (
-                result := ctx.get_type_dependency(cls, default=UNDEFINED)
-            ) is not UNDEFINED:
+            if (result := ctx.get_type_dependency(cls, default=UNDEFINED)) is not UNDEFINED:
                 return result
 
         if self.default is not UNDEFINED:
             return self.default
 
         raise _errors.MissingDependencyError(
-            f"Couldn't resolve injected type(s) {self.repr_type} to actual value",
-            self.repr_type,
+            f"Couldn't resolve injected type(s) {self.repr_type} to actual value", self.repr_type
         ) from None
 
 

--- a/alluka/_types.py
+++ b/alluka/_types.py
@@ -30,6 +30,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """Internal types used by Alluka."""
 from __future__ import annotations
+from typing import Any
 
 __all__: list[str] = ["Injected", "InjectedDescriptor"]
 
@@ -91,10 +92,14 @@ class InjectedCallback:
             If any of the callback's type dependencies aren't implemented by
             the context's client.
         """
-        callback = ctx.injection_client.get_callback_override(self.callback) or self.callback
+        callback = (
+            ctx.injection_client.get_callback_override(self.callback) or self.callback
+        )
         return ctx.injection_client.call_with_ctx(ctx, callback)
 
-    def resolve_async(self, ctx: alluka.Context) -> collections.Coroutine[typing.Any, typing.Any, typing.Any]:
+    def resolve_async(
+        self, ctx: alluka.Context
+    ) -> collections.Coroutine[typing.Any, typing.Any, typing.Any]:
         """Asynchronously resolve the callback.
 
         Parameters
@@ -108,7 +113,9 @@ class InjectedCallback:
             If any of the callback's type dependencies aren't implemented by
             the context's client.
         """
-        callback = ctx.injection_client.get_callback_override(self.callback) or self.callback
+        callback = (
+            ctx.injection_client.get_callback_override(self.callback) or self.callback
+        )
         return ctx.injection_client.call_with_ctx_async(ctx, callback)
 
 
@@ -155,14 +162,17 @@ class InjectedType:
             The resolved type.
         """
         for cls in self.types:
-            if (result := ctx.get_type_dependency(cls, default=UNDEFINED)) is not UNDEFINED:
+            if (
+                result := ctx.get_type_dependency(cls, default=UNDEFINED)
+            ) is not UNDEFINED:
                 return result
 
         if self.default is not UNDEFINED:
             return self.default
 
         raise _errors.MissingDependencyError(
-            f"Couldn't resolve injected type(s) {self.repr_type} to actual value", self.repr_type
+            f"Couldn't resolve injected type(s) {self.repr_type} to actual value",
+            self.repr_type,
         ) from None
 
 
@@ -255,6 +265,11 @@ class InjectedDescriptor(typing.Generic[_T]):
 
         self.callback = callback
         self.type = type
+
+    def __getattr__(self, __name: str) -> Any:
+        raise AttributeError(
+            "Tried accessing a parameter that was not injected yet. Did you forget to inject dependencies?"
+        )
 
 
 Injected = typing.Annotated[_T, InjectedTypes.TYPE]


### PR DESCRIPTION
### Summary
This is a small PR aimed at improving the error message emitted when trying to access an attribute of an `InjectedDescriptor`. This should only happen if the user calls a function without DI that has `alluka.inject()` defaults set, and then tries accessing attributes of one such parameter.

So instead of an error like this:
```
AttributeError: 'InjectedDescriptor' object has no attribute 'value'
```

You get this:

```
AttributeError: Tried accessing a parameter that was not injected yet. Did you forget to inject dependencies?
```

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

