### PR TITLE
More consistently use _types.NO_VALUE

### DIFF
--- a/alluka/_client.py
+++ b/alluka/_client.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 __all__: list[str] = ["Client", "inject"]
 
 import asyncio
-import enum
 import typing
 import warnings
 import weakref
@@ -65,14 +64,6 @@ _DefaultT = typing.TypeVar("_DefaultT")
 _SyncCallbackSigT = typing.TypeVar("_SyncCallbackSigT", bound=collections.Callable[..., typing.Any])
 
 _TypeT = type[_T]
-
-
-class _NoDefaultEnum(enum.Enum):
-    VALUE = object()
-
-
-_NO_VALUE: typing.Literal[_NoDefaultEnum.VALUE] = _NoDefaultEnum.VALUE
-_NoValueOr = typing.Union[_T, typing.Literal[_NoDefaultEnum.VALUE]]
 
 
 @typing.overload
@@ -285,12 +276,12 @@ class Client(alluka.Client):
     def get_type_dependency(self, type_: type[_T], /, *, default: _DefaultT) -> typing.Union[_T, _DefaultT]: ...
 
     def get_type_dependency(
-        self, type_: type[_T], /, *, default: _NoValueOr[_DefaultT] = _NO_VALUE
+        self, type_: type[_T], /, *, default: _types.NoValueOr[_DefaultT] = _types.NoValue
     ) -> typing.Union[_T, _DefaultT]:
         # <<inherited docstring from alluka.abc.Client>>.
         result = self._type_dependencies.get(type_, default)
 
-        if result is _NO_VALUE:
+        if result is _types.NoValue:
             raise KeyError
 
         return result

--- a/alluka/_context.py
+++ b/alluka/_context.py
@@ -36,11 +36,11 @@ from __future__ import annotations
 
 __all__: list[str] = ["BasicContext", "CachingContext", "Context", "OverridingContext"]
 
-import enum
 import typing
 
 import typing_extensions
 
+from . import _types  # type: ignore[reportPrivateUsage]
 from . import abc as alluka
 
 if typing.TYPE_CHECKING:
@@ -51,14 +51,6 @@ _T = typing.TypeVar("_T")
 
 
 _DefaultT = typing.TypeVar("_DefaultT")
-
-
-class _NoDefaultEnum(enum.Enum):
-    VALUE = object()
-
-
-_NO_VALUE: typing.Literal[_NoDefaultEnum.VALUE] = _NoDefaultEnum.VALUE
-_NoValueOr = typing.Union[_T, typing.Literal[_NoDefaultEnum.VALUE]]
 
 
 class Context(alluka.Context):
@@ -88,7 +80,7 @@ class Context(alluka.Context):
     def get_type_dependency(self, type_: type[_T], /, *, default: _DefaultT) -> typing.Union[_T, _DefaultT]: ...
 
     def get_type_dependency(
-        self, type_: type[_T], /, *, default: _NoValueOr[_DefaultT] = _NO_VALUE
+        self, type_: type[_T], /, *, default: _types.NoValueOr[_DefaultT] = _types.NO_VALUE
     ) -> typing.Union[_T, _DefaultT]:
         # <<inherited docstring from alluka.abc.Context>>.
         if type_ is alluka.Context:
@@ -96,7 +88,7 @@ class Context(alluka.Context):
 
         result = self._client.get_type_dependency(type_, default=default)
 
-        if result is _NO_VALUE:
+        if result is _types.NO_VALUE:
             raise KeyError
 
         return result
@@ -131,12 +123,12 @@ class CachingContext(Context):
     ) -> typing.Union[_T, _DefaultT]: ...
 
     def get_cached_result(
-        self, callback: alluka.CallbackSig[_T], /, *, default: _NoValueOr[_DefaultT] = _NO_VALUE
+        self, callback: alluka.CallbackSig[_T], /, *, default: _types.NoValueOr[_DefaultT] = _types.NO_VALUE
     ) -> typing.Union[_T, _DefaultT]:
         # <<inherited docstring from alluka.abc.Context>>.
         result = self._result_cache.get(callback, default)
 
-        if result is _NO_VALUE:
+        if result is _types.NO_VALUE:
             raise KeyError
 
         return result
@@ -212,11 +204,11 @@ class OverridingContext(alluka.Context):
     ) -> typing.Union[_T, _DefaultT]: ...
 
     def get_cached_result(
-        self, callback: alluka.CallbackSig[_T], /, *, default: _NoValueOr[_DefaultT] = _NO_VALUE
+        self, callback: alluka.CallbackSig[_T], /, *, default: _types.NoValueOr[_DefaultT] = _types.NO_VALUE
     ) -> typing.Union[_T, _DefaultT]:
         value = self._context.get_cached_result(callback, default=default)
 
-        if value is _NO_VALUE:
+        if value is _types.NO_VALUE:
             raise KeyError
 
         return value
@@ -231,14 +223,14 @@ class OverridingContext(alluka.Context):
     def get_type_dependency(self, type_: type[_T], /, *, default: _DefaultT) -> typing.Union[_T, _DefaultT]: ...
 
     def get_type_dependency(
-        self, type_: type[_T], /, *, default: _NoValueOr[_DefaultT] = _NO_VALUE
+        self, type_: type[_T], /, *, default: _types.NoValueOr[_DefaultT] = _types.NO_VALUE
     ) -> typing.Union[_T, _DefaultT]:
         # <<inherited docstring from alluka.abc.Context>>.
         value = self._overrides.get(type_, default)
         if value is default:
             value = self._context.get_type_dependency(type_, default=default)
 
-        if value is _NO_VALUE:
+        if value is _types.NO_VALUE:
             raise KeyError
 
         return value
@@ -282,14 +274,14 @@ class BasicContext(CachingContext):
     def get_type_dependency(self, type_: type[_T], /, *, default: _DefaultT) -> typing.Union[_T, _DefaultT]: ...
 
     def get_type_dependency(
-        self, type_: type[_T], /, *, default: _NoValueOr[_DefaultT] = _NO_VALUE
+        self, type_: type[_T], /, *, default: _types.NoValueOr[_DefaultT] = _types.NO_VALUE
     ) -> typing.Union[_T, _DefaultT]:
         # <<inherited docstring from alluka.abc.Context>>.
         value = self._special_case_types.get(type_, default)
         if value is default:
             value = super().get_type_dependency(type_, default=default)
 
-        if value is _NO_VALUE:
+        if value is _types.NO_VALUE:
             raise KeyError
 
         return value

--- a/alluka/_types.py
+++ b/alluka/_types.py
@@ -38,22 +38,27 @@ import enum
 import typing
 
 from . import _errors  # pyright: ignore[reportPrivateUsage]
-from . import abc as alluka
 
 if typing.TYPE_CHECKING:
     from collections import abc as collections
+
+    from . import abc as alluka
 
 
 _T = typing.TypeVar("_T")
 
 
-class _UndefinedEnum(enum.Enum):
-    UNDEFINED = object()
+class _NoValueEnum(enum.Enum):
+    NO_VALUE = object()
 
 
-UNDEFINED = _UndefinedEnum.UNDEFINED
-"""Singleton used internally to indicate that a value is undefined."""
-UndefinedOr = typing.Union[_T, typing.Literal[_UndefinedEnum.UNDEFINED]]
+NO_VALUE = _NoValueEnum.NO_VALUE
+"""Singleton used internally to indicate that no value was provided."""
+
+NoValue = typing.Literal[_NoValueEnum.NO_VALUE]
+"""Type of [NO_VALUE]."""
+
+NoValueOr = typing.Union[_T, NoValue]
 """Union for a value which may be undefined."""
 
 
@@ -124,7 +129,7 @@ class InjectedType:
         types: collections.Sequence[type[typing.Any]],
         /,
         *,
-        default: UndefinedOr[typing.Any] = UNDEFINED,
+        default: NoValueOr[typing.Any] = NO_VALUE,
     ) -> None:
         """Initialize the type descriptor.
 
@@ -156,10 +161,10 @@ class InjectedType:
             The resolved type.
         """
         for cls in self.types:
-            if (result := ctx.get_type_dependency(cls, default=UNDEFINED)) is not UNDEFINED:
+            if (result := ctx.get_type_dependency(cls, default=NO_VALUE)) is not NO_VALUE:
                 return result
 
-        if self.default is not UNDEFINED:
+        if self.default is not NO_VALUE:
             return self.default
 
         raise _errors.MissingDependencyError(

--- a/alluka/abc.py
+++ b/alluka/abc.py
@@ -37,12 +37,13 @@ from __future__ import annotations
 __all__: list[str] = ["AsyncSelfInjecting", "CallbackSig", "Client", "Context", "SelfInjecting"]
 
 import abc
-import enum
 import functools
 import typing
 from collections import abc as collections
 
 import typing_extensions
+
+from . import _types  # pyright: ignore[reportPrivateUsage]
 
 if typing.TYPE_CHECKING:
     from typing_extensions import Self
@@ -54,14 +55,6 @@ _CoroT = collections.Coroutine[typing.Any, typing.Any, _T]
 _CallbackT = typing.TypeVar("_CallbackT", bound="CallbackSig[typing.Any]")
 _DefaultT = typing.TypeVar("_DefaultT")
 _SyncCallbackT = typing.TypeVar("_SyncCallbackT", bound=collections.Callable[..., typing.Any])
-
-
-class _NoDefaultEnum(enum.Enum):
-    VALUE = object()
-
-
-_NO_VALUE: typing.Literal[_NoDefaultEnum.VALUE] = _NoDefaultEnum.VALUE
-_NoValueOr = typing.Union[_T, typing.Literal[_NoDefaultEnum.VALUE]]
 
 
 CallbackSig = collections.Callable[..., typing.Union[_CoroT[_T], _T]]
@@ -544,7 +537,7 @@ class Context(abc.ABC):
     def get_cached_result(self, callback: CallbackSig[_T], /, *, default: _DefaultT) -> typing.Union[_T, _DefaultT]: ...
 
     def get_cached_result(
-        self, callback: CallbackSig[_T], /, *, default: _NoValueOr[_DefaultT] = _NO_VALUE
+        self, callback: CallbackSig[_T], /, *, default: _types.NoValueOr[_DefaultT] = _types.NO_VALUE
     ) -> typing.Union[_T, _DefaultT]:
         """Get the cached result of a callback.
 
@@ -571,7 +564,7 @@ class Context(abc.ABC):
         KeyError
             If no value was found when no default was provided.
         """
-        if default is _NO_VALUE:
+        if default is _types.NO_VALUE:
             raise KeyError
 
         return default


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
